### PR TITLE
Tanktier detection changes

### DIFF
--- a/missingtanks.json
+++ b/missingtanks.json
@@ -13,5 +13,10 @@
     "tier": 10,
     "tag": "A84_M48A1",
     "short_name": "M48A1"
-    }
+    },
+  "PzIII_A": {
+    "tier": 3,
+    "tag": "PzIII_A",
+    "short_name": "PzIII_A"
+  }
 }


### PR DESCRIPTION
The code is not nice and pretty, since I am unfamiliar with Python, but I think you get the idea.
No problem if you reject this pull request, also...

I have a lot lower tier tanks tanks that reported non-existing names in the older replays (T-46 for example instead of R22_T-46)

Also excluded the Haloween tanks, and included a tank in the missing json

Regards, forkboy1 (WoT playername)