### PR TITLE
Bugfix too many replay file skipped

### DIFF
--- a/replay_parser.py
+++ b/replay_parser.py
@@ -37,7 +37,7 @@ class ReplayParser:
             if (len(json_data.get('vehicles')) < 30 or               # not full team
                     json_data.get('regionCode') == 'CT' or           # test server
                     json_data.get('bootcampCtx') or                  # tutorial
-                    json_data.get('gameplayID') in ['sandbox']):     # proving grounds
+                    json_data.get('gameplayID') == 'sandbox'):       # proving grounds
                 return None
 
             if parts == 2:

--- a/replay_parser.py
+++ b/replay_parser.py
@@ -37,9 +37,9 @@ class ReplayParser:
             if (len(json_data.get('vehicles')) < 30 or               # not full team
                     json_data.get('regionCode') == 'CT' or           # test server
                     json_data.get('bootcampCtx') or                  # tutorial
-                    json_data.get('gameplayID') in ['sandbox',       # proving grounds
-                                                    'domination']):  # halloween mode 2017
+                    json_data.get('gameplayID') in ['sandbox']):     # proving grounds
                 return None
+
             if parts == 2:
                 d = r.read(4)
                 data['ext'] = self._extract_json_data(d[0:4], r)

--- a/replay_parser.py
+++ b/replay_parser.py
@@ -49,7 +49,7 @@ class ReplayParser:
         for directory in self.directorys:
             files = glob.glob(directory + os.path.sep + '*wotreplay')
             for i, replay in enumerate(files):
-                if replay in ['replay_last_battle.wotreplay', 'temp.wotreplay']:
+                if replay.endswith('replay_last_battle.wotreplay') or replay.endswith('temp.wotreplay'):
                     continue
                 self.ow.print(f'{i+1}/{len(files)} - {replay}')
                 json_data = self._load_json_from_replay(replay)

--- a/replay_parser.py
+++ b/replay_parser.py
@@ -37,7 +37,8 @@ class ReplayParser:
             if (len(json_data.get('vehicles')) < 30 or               # not full team
                     json_data.get('regionCode') == 'CT' or           # test server
                     json_data.get('bootcampCtx') or                  # tutorial
-                    json_data.get('gameplayID') == 'sandbox'):       # proving grounds
+                    json_data.get('gameplayID') == 'sandbox' or      # proving grounds
+                    json_data.get('mapName') == '120_kharkiv_halloween'):       # Halloween 2017
                 return None
 
             if parts == 2:

--- a/replay_parser.py
+++ b/replay_parser.py
@@ -50,7 +50,7 @@ class ReplayParser:
         for directory in self.directorys:
             files = glob.glob(directory + os.path.sep + '*wotreplay')
             for i, replay in enumerate(files):
-                if replay.endswith('replay_last_battle.wotreplay') or replay.endswith('temp.wotreplay'):
+                if replay.rsplit (os.path.sep, 1)[-1] in ('replay_last_battle.wotreplay', 'temp.wotreplay'):
                     continue
                 self.ow.print(f'{i+1}/{len(files)} - {replay}')
                 json_data = self._load_json_from_replay(replay)


### PR DESCRIPTION
I had many replay files being skipped due to the filter on gameplayID domination. From my 9 replays of yesterday only 4 remained. The other 5 (including also results) were skipped.

This gameplayID seems not to be the selector, since this is a encounter battle. See also: http://wiki.vbaddict.net/pages/GameplayID.